### PR TITLE
Ignore MoonBit build artifacts in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 target/
 .mooncakes/
 .moonagent/
+_build/
+target

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/
 .moonagent/
 _build/
 target
+_build


### PR DESCRIPTION
**Summary**
- Add `target` and `_build` to `.gitignore` to exclude build outputs from version control.

**Why**
- Part of the deprecated-warning cleanup effort and future migration prep; ignoring build artifacts keeps the repo clean and avoids noise from generated files.

**Implementation Details**
- Updated `.gitignore` with two entries for MoonBit build directories.